### PR TITLE
Migrate to .Net 5 and Umbraco 9

### DIFF
--- a/src/Our.Umbraco.AnimateOnScroll/Models/Animation.cs
+++ b/src/Our.Umbraco.AnimateOnScroll/Models/Animation.cs
@@ -1,10 +1,7 @@
 ﻿using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Web;
+using Microsoft.AspNetCore.Html;
 
 namespace Our.Umbraco.AnimateOnScroll.Models
 {
@@ -64,7 +61,7 @@ namespace Our.Umbraco.AnimateOnScroll.Models
             );
         }
 
-        public IHtmlString ToHtml()
+        public IHtmlContent ToHtml()
         {
             return new HtmlString(ToString());
         }

--- a/src/Our.Umbraco.AnimateOnScroll/Our.Umbraco.AnimateOnScroll.csproj
+++ b/src/Our.Umbraco.AnimateOnScroll/Our.Umbraco.AnimateOnScroll.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>Our.Umbraco.AnimateOnScroll</RootNamespace>
 
 		<IncludeContentInPack>true</IncludeContentInPack>
@@ -16,7 +16,8 @@
 	</PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="UmbracoCms.Web" Version="8.6.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Html.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Umbraco.Cms.Web.Common" Version="9" />
   </ItemGroup>
 
 	<ItemGroup>

--- a/src/Our.Umbraco.AnimateOnScroll/ValueConverters/AnimateOnScrollValueConverter.cs
+++ b/src/Our.Umbraco.AnimateOnScroll/ValueConverters/AnimateOnScrollValueConverter.cs
@@ -1,13 +1,9 @@
 ﻿using Newtonsoft.Json.Linq;
 using Our.Umbraco.AnimateOnScroll.Models;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Umbraco.Core;
-using Umbraco.Core.Models.PublishedContent;
-using Umbraco.Core.PropertyEditors;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Extensions;
 
 namespace Our.Umbraco.AnimateOnScroll.ValueConverters
 {


### PR DESCRIPTION
I upgrade your property editor to use in Umbraco 9. There was not need many changes. I was update only dependencies and I was make a little changs in C# code to adapt it to new dependencies. All backoffice files are still the same and there is not needed to change it.